### PR TITLE
Agrego script para probar rápido el reconocimiento

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Slack: https://losborbotones.slack.com
 #### install:
 ```bash
 # install nodejs
-# install npm (node's package manager)
+# install npm (node package manager)
 
 npm install -g grunt-cli
 npm install
@@ -41,6 +41,12 @@ node
 #your debugging code:
 Monkey = include("domains/monkey")
 # ...
+```
+
+#### record & play:
+```
+#requires arecord & timidity
+./tester.sh
 ```
 
 #### deploy:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ grunt test
 ```
 
 #### REPL shell:
-```shell
+```bash
 node
 .load globals.js
 #your debugging code:
@@ -44,7 +44,7 @@ Monkey = include("domains/monkey")
 ```
 
 #### record & play:
-```
+```bash
 #requires arecord & timidity
 ./tester.sh
 ```

--- a/tester.js
+++ b/tester.js
@@ -1,0 +1,16 @@
+require("./globals");
+var MelodyDetector = include("melodyDetector");
+var MidiFile = include("midiFile");
+
+var settings = {
+  filePath: "tmp.wav",
+  tempo: 120,
+  bar: { major: 4, minor: 4 },
+  clef: "G"
+}
+
+new MelodyDetector(settings)
+  .getMelody()
+  .then(function(melody) {
+    new MidiFile(melody).save("tmp.mid")
+  });

--- a/tester.sh
+++ b/tester.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+arecord -f dat -D hw:0,0 tmp.wav
+node ./tester.js
+timidity tmp.mid
+rm tmp.wav tmp.mid


### PR DESCRIPTION
Esto es algo que tenía ganas de hacer hace rato. Es para poder probar rápido el reconocimiento de audio.

Se necesita instalar **timidity** (también **arecord**, pero creo que viene con cualquier distro de Linux al ser parte de ALSA, el driver de audio del kernel). Esto se haría con **sudo apt-get install timidity**.

Luego se puede correr el script con **./tester.sh**, va a empezar a grabar, al apretar Ctrl+C va a terminar de grabar y va a permitir escuchar el midi generado.