### PR TITLE
Guardar blobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 src/config/env.coffee
-uploads/
+blobs/
 *.sublime-workspace
 *.log
 *.wav

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "coffee-script": "^1.9.2",
     "express": "^4.12.4",
     "jsmidgen": "^0.1.2",
+    "mkdirp": "^0.5.1",
     "morgan": "^1.5.3",
     "multer": "^0.1.8",
-    "protolodash": "^3.10.0"
+    "protolodash": "^3.10.0",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/src/config/env.sample.coffee
+++ b/src/config/env.sample.coffee
@@ -2,5 +2,6 @@
 # to automatically export them to the environment. Example:
 
 # module.exports =
+#   DOMAIN: "http://localhost:8081"
 #   VARIABLE_NAME: "a value"
 #   ANOTHER_VARIABLE: "another value"

--- a/src/controllers/melodyController.coffee
+++ b/src/controllers/melodyController.coffee
@@ -1,6 +1,6 @@
 MelodyDetector = include("models/generators/melodyDetector")
-unlink = require("fs").unlinkSync
 MidiFile = include("models/generators/midiFile")
+fs = require("fs")
 uuid = require("uuid")
 _ = require("protolodash")
 
@@ -55,6 +55,7 @@ class MelodyController
       { name: "tempo", type: "isNumber", values: [1 .. 250], parse: true }
       { name: "major", type: "isNumber", values: [1 .. 32], parse: true }
       { name: "minor", type: "isNumber", values: [1, 4, 8, 16], parse: true }
+      { name: "key", type: "isString", values: ["Abm", "Ebm", "Bbm", "Fm", "Cm", "Gm", "Dm", "Am", "Em", "Bm", "F#m", "C#m", "G#m", "D#m", "A#m", "Cb", "Gb", "Db", "Ab", "Eb", "Bb", "F", "C", "G", "D", "A", "E", "B", "F#", "C#"] }
       { name: "clef", type: "isString", values: ["G", "C", "F"] }
     ].forEach (it) =>
       value = req.body[it.name]
@@ -69,7 +70,6 @@ class MelodyController
   ###
   _deleteFiles: (req) ->
     for name, file of req.files
-      unlink file.path
       fs.unlink file.path
 
 module.exports = (app) =>

--- a/src/controllers/melodyController.coffee
+++ b/src/controllers/melodyController.coffee
@@ -1,5 +1,7 @@
 MelodyDetector = include("models/generators/melodyDetector")
 unlink = require("fs").unlinkSync
+MidiFile = include("models/generators/midiFile")
+uuid = require("uuid")
 _ = require("protolodash")
 
 ###
@@ -7,7 +9,7 @@ A controller that manages audio recognition.
 ###
 class MelodyController
   ###
-  Recognizes an audio file, returns the MIDI & MusicXML.
+  Recognizes an audio file, returns the links to the MIDI and the Score.
   ###
   recognize: (req, res) =>
     errors = @_parseAndFindErrors req
@@ -23,8 +25,22 @@ class MelodyController
 
     new MelodyDetector(settings)
       .getMelody()
-      .then (melody) => res.json melody
+      .then (melody) =>
+        @_generateMidiAndMusicXml(melody).then (links) =>
+          res.json links
       .finally => @_deleteFiles req
+
+  ###
+  Generates and stores the MIDI and the MusicXML file.
+  It returns a promises with links.
+  ###
+  _generateMidiAndMusicXml: (melody) =>
+    id = uuid.v4()
+    new MidiFile(melody)
+      .save("#{__rootpath}/blobs/midis/#{id}.mid")
+      .then =>
+        midi: "#{process.env.DOMAIN}/midis/#{id}.mid"
+        score: "#{process.env.DOMAIN}/scores/coming_soon"
 
   ###
   Parse the numbers and find possible errors in the request.
@@ -54,6 +70,7 @@ class MelodyController
   _deleteFiles: (req) ->
     for name, file of req.files
       unlink file.path
+      fs.unlink file.path
 
 module.exports = (app) =>
   ctrl = new MelodyController()

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -11,9 +11,15 @@ module.exports = =>
   app = express()
   app.use require("body-parser").json limit: "50mb" # json parser
   app.use require("morgan") "dev" # logger
-  app.use require("multer") dest: "#{__rootpath}/uploads" # multipart files
+  app.use require("multer") dest: "#{__rootpath}/blobs/uploads" # multipart files
+  app.use express.static("blobs") # serve blobs
 
   require("./routes") app
+
+  # ensure the blobs directories exist
+  mkdirp = require("mkdirp")
+  mkdirp "#{__rootpath}/blobs/midis"
+  mkdirp "#{__rootpath}/blobs/musicxmls"
 
   app.listen port
   console.log "[!] Listening in port #{port}"

--- a/src/models/generators/midiFile.coffee
+++ b/src/models/generators/midiFile.coffee
@@ -1,5 +1,6 @@
 Midi = require("jsmidgen")
-fs = require("fs")
+promisify = require("bluebird").promisifyAll
+fs = promisify require("fs")
 
 ###
 A MIDI File created by a *melody*.
@@ -29,7 +30,7 @@ class MidiFile
   Exports the file into a *path*.
   ###
   save: (path) =>
-    fs.writeFileSync path, @file.toBytes(), "binary"
+    fs.writeFileAsync path, @file.toBytes(), "binary"
 
   ###
   Get ticks with jsmidigen beats convention.


### PR DESCRIPTION
# Mergeado con `git pull`.

- Los blobs (en principio, solo MIDIs) se guardan en una carpeta `/blobs` que contiene los midis, musicxmls, y los m4a temporales que suben las personas, con un id único generado.
- Se le devuelve al usuario un link a ese MIDI que es accesible, ya que ahora **express* ve a esa carpeta como un recurso estático.
- Se reemplazaron todos los `sarasaFileSync` por su alternativa asincrónica ya que no queremos que se bloquee el único hilo que tiene node al leer un directorio, por ejemplo (leí en stackoverflow que era una muy mala práctica).